### PR TITLE
[codex] update template base image registry

### DIFF
--- a/template/cookiecutter.json
+++ b/template/cookiecutter.json
@@ -9,7 +9,7 @@
     "apigw_cors_allow_methods": "GET,POST,PUT,PATCH,HEAD,DELETE,OPTIONS",
     "apigw_cors_allow_headers": "Accept,Cache-Control,Content-Type,Keep-Alive,Origin,User-Agent,X-Requested-With",
     "bk_apigw_default_timeout": "60",
-    "base_image": "bk-plugin-python-base:2.3.14",
+    "base_image": "mirrors.tencent.com/bkplugin/bk-plugin-python-base:2.3.14",
     "_copy_without_render": [
         ".ci"
     ]


### PR DESCRIPTION
## Summary
- Update the cookiecutter template default base image to use the full Tencent mirror path.
- Keep the generated plugin Dockerfile configurable through the existing base_image template variable.

## Impact
- Newly generated plugin Dockerfiles will reference mirrors.tencent.com/bkplugin/bk-plugin-python-base:2.3.14 by default.
- Existing generated plugins are not changed.

## Validation
- python -m json.tool template/cookiecutter.json >/dev/null
- python -m pytest bk-plugin-framework/tests/template/test_docker_template.py -q