### PR TITLE
[codex] Add APIGW schedule polling resource

### DIFF
--- a/bk-plugin-framework/bk_plugin_framework/services/bpf_service/management/commands/support-files/resources.yaml
+++ b/bk-plugin-framework/bk_plugin_framework/services/bpf_service/management/commands/support-files/resources.yaml
@@ -121,6 +121,52 @@ paths:
           resourcePermissionRequired: true
         disabledStages: []
         descriptionEn: Invoke specific version plugin
+
+  /bk_plugin/schedule/{id}:
+    get:
+      operationId: schedule
+      summary: 获取插件调度详情
+      description: 根据 trace_id 获取插件调度详情
+      tags:
+        - schedule
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+          description: 插件调用 trace id
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnvelopedScheduleResponse'
+          description: '查询成功'
+      x-bk-apigateway-resource:
+        isPublic: true
+        matchSubpath: false
+        backend:
+          type: HTTP
+          name: default
+          method: get
+          {% if settings.BK_PLUGIN_APIGW_BACKEND_SUB_PATH %}
+          path: /{env.api_sub_path}/bk_plugin/schedule/{id}
+          {% else %}
+          path: /bk_plugin/schedule/{id}
+          {% endif %}
+          matchSubpath: false
+          timeout: 0
+          upstreams: {}
+          transformHeaders: {}
+        pluginConfigs: []
+        allowApplyPermission: true
+        authConfig:
+          userVerifiedRequired: false
+          appVerifiedRequired: true
+          resourcePermissionRequired: false
+        disabledStages: []
+        descriptionEn: Get plugin schedule detail with trace_id
   /bk_plugin/plugin_api/:
     x-bk-apigateway-method-any:
       operationId: plugin_api
@@ -370,6 +416,64 @@ components:
         - result
         - trace_id
 
+    ScheduleData:
+      type: object
+      description: 插件调度返回数据
+      properties:
+        trace_id:
+          type: string
+          description: 插件调用 trace id
+        plugin_version:
+          type: string
+          description: 插件版本
+        state:
+          type: integer
+          description: '插件执行状态(2: POLL 3:CALLBACK 4:SUCCESS 5:FAIL)'
+        outputs:
+          type: object
+          additionalProperties: {}
+          description: 插件输出
+        err:
+          type: string
+          description: 错误信息
+        created_at:
+          type: string
+          description: 创建时间
+        finish_at:
+          type: string
+          description: 结束时间
+      required:
+        - created_at
+        - err
+        - finish_at
+        - outputs
+        - plugin_version
+        - state
+        - trace_id
+
+    ScheduleResponse:
+      type: object
+      description: 插件调度响应
+      properties:
+        result:
+          type: boolean
+          description: 请求是否成功
+        message:
+          type: string
+          description: 请求额外信息，result 为 false 时读取
+        trace_id:
+          type: string
+          description: 调用跟踪 ID
+        data:
+          allOf:
+            - $ref: '#/components/schemas/ScheduleData'
+          description: 接口数据
+      required:
+        - data
+        - message
+        - result
+        - trace_id
+
     PluginCallbackResponse:
       type: object
       description: 插件回调响应
@@ -416,6 +520,27 @@ components:
           description: 状态码，0表示成功
         data:
           $ref: '#/components/schemas/InvokeResponse'
+        message:
+          type: string
+          description: 响应消息
+        result:
+          type: boolean
+          description: 操作结果
+      required:
+        - code
+        - data
+        - message
+        - result
+
+    EnvelopedScheduleResponse:
+      type: object
+      description: 插件调度统一响应封装
+      properties:
+        code:
+          type: integer
+          description: 状态码，0表示成功
+        data:
+          $ref: '#/components/schemas/ScheduleResponse'
         message:
           type: string
           description: 响应消息

--- a/bk-plugin-framework/tests/services/bpf_service/test_resources_yaml.py
+++ b/bk-plugin-framework/tests/services/bpf_service/test_resources_yaml.py
@@ -1,0 +1,51 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - PaaS平台 (BlueKing - PaaS System) available.
+Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from pathlib import Path
+
+import yaml
+from django.template import Context, Engine
+
+
+RESOURCE_TEMPLATE = (
+    Path(__file__).parents[3]
+    / "bk_plugin_framework"
+    / "services"
+    / "bpf_service"
+    / "management"
+    / "commands"
+    / "support-files"
+    / "resources.yaml"
+)
+
+
+class TestGatewayResources:
+    def test_schedule_resource_is_public_and_requires_app_auth_only(self):
+        engine = Engine()
+        expected_backend_paths = [
+            ("", "/bk_plugin/schedule/{id}"),
+            ("subpath", "/{env.api_sub_path}/bk_plugin/schedule/{id}"),
+        ]
+
+        for backend_sub_path, expected_backend_path in expected_backend_paths:
+            rendered = engine.from_string(RESOURCE_TEMPLATE.read_text(encoding="utf-8")).render(
+                Context({"settings": {"BK_PLUGIN_APIGW_BACKEND_SUB_PATH": backend_sub_path}})
+            )
+            resource = yaml.safe_load(rendered)["paths"]["/bk_plugin/schedule/{id}"]["get"]["x-bk-apigateway-resource"]
+
+            assert resource["isPublic"] is True
+            assert resource["allowApplyPermission"] is True
+            assert resource["authConfig"] == {
+                "userVerifiedRequired": False,
+                "appVerifiedRequired": True,
+                "resourcePermissionRequired": False,
+            }
+            assert resource["backend"]["path"] == expected_backend_path


### PR DESCRIPTION
## What

- Add an APIGW resource for `GET /bk_plugin/schedule/{id}` and route it to the existing backend schedule endpoint.
- Keep the runtime schedule API behavior unchanged: no new framework setting, no new DRF permission check, and existing direct calls still behave as before.
- Configure the schedule resource as public/apply-able with app authentication only:
  - `isPublic: true`
  - `allowApplyPermission: true`
  - `userVerifiedRequired: false`
  - `appVerifiedRequired: true`
  - `resourcePermissionRequired: false`

## Why

External platforms can poll plugin execution status through APIGW using the same schedule interface shape, while the gateway handles application identity verification.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 DJANGO_SETTINGS_MODULE=tests.settings PYTHONPATH=. pytest tests/services/bpf_service/test_resources_yaml.py -q`
- `black --check tests/services/bpf_service/test_resources_yaml.py`
- `flake8 tests/services/bpf_service/test_resources_yaml.py`
- `git diff --check origin/master`
- GitHub Actions after `e8a69fb`: CodeQL, framework unittest, framework lint, runtime lint all passed.